### PR TITLE
ops: replace version tags with SHAs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -26,7 +26,7 @@ runs:
   steps:
     - run: echo Running edgetest with the following options ${{ inputs.edgetest-flags }}.
       shell: bash
-    - uses: conda-incubator/setup-miniconda@v3
+    - uses: conda-incubator/setup-miniconda@fc2d68f6413eb2d87b895e92f8584b5b94a10167  # v3.3.0
       with:
         auto-update-conda: true
         python-version: ${{ inputs.python-version }}
@@ -41,7 +41,7 @@ runs:
         edgetest ${{ inputs.edgetest-flags }}
     - name: Create Pull Request
       if: ${{ inputs.skip-pr == 'false' }}
-      uses: peter-evans/create-pull-request@v7
+      uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676  # v7.0.11
       with:
         branch: edgetest-patch
         base: ${{ inputs.base-branch }}


### PR DESCRIPTION
don't think I updated anything - just went to the latest release of the specified major version. both have had 1 major version bump since the pinned versions